### PR TITLE
Replace with commons-io:commons-io instead of apache version

### DIFF
--- a/trustedshops-android-sdk/build.gradle
+++ b/trustedshops-android-sdk/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.squareup.okhttp3:okhttp:3.1.2'
     compile 'com.afollestad.material-dialogs:core:0.9.3.0'
-    compile 'org.apache.directory.studio:org.apache.commons.codec:1.8'
+    compile 'commons-io:commons-io:2.4'
     testCompile 'commons-io:commons-io:2.4'
     testCompile 'org.json:json:20160212'
 

--- a/trustedshops-android-sdk/build.gradle
+++ b/trustedshops-android-sdk/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile 'com.squareup.okhttp3:okhttp:3.1.2'
     compile 'com.afollestad.material-dialogs:core:0.9.3.0'
-    compile 'commons-io:commons-io:2.4'
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
     testCompile 'commons-io:commons-io:2.4'
     testCompile 'org.json:json:20160212'
 

--- a/trustedshops-android-sdk/build.gradle
+++ b/trustedshops-android-sdk/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.squareup.okhttp3:okhttp:3.1.2'
     compile 'com.afollestad.material-dialogs:core:0.9.3.0'
     compile 'org.apache.directory.studio:org.apache.commons.codec:1.8'
-    testCompile 'org.apache.directory.studio:org.apache.commons.io:2.4'
+    testCompile 'commons-io:commons-io:2.4'
     testCompile 'org.json:json:20160212'
 
 }


### PR DESCRIPTION
Using `org.apache.directory.studio:org.apache.commons.io:2.4` instead of `commons-io:commons-io:2.4` causes our production deployments to be available to 0 devices. Issue caused by `org.apache.directory.studio:org.apache.commons.io:2.4`

As you can see here, 0 devices are supported
![image](https://user-images.githubusercontent.com/1169240/36024706-3c20f0cc-0d99-11e8-8f31-a5c593b822e7.png)
